### PR TITLE
refactor: use `qrcode.react` types from package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.0",
     "@votingworks/ballot-encoder": "^1.2.0",
-    "@votingworks/qrcode.react": "^1.0.0",
+    "@votingworks/qrcode.react": "1.0.1",
     "dashify": "^2.0.0",
     "normalize.css": "^8.0.1",
     "object-hash": "^2.0.3",

--- a/client/src/components/QRCode.tsx
+++ b/client/src/components/QRCode.tsx
@@ -1,4 +1,4 @@
-import QRCodeReact from '@votingworks/qrcode.react'
+import QRCodeReact, { QRCodeProps } from '@votingworks/qrcode.react'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -9,15 +9,6 @@ const ResponsiveSvgWrapper = styled.div`
     height: auto; /* reset height */
   }
 `
-
-interface QRCodeProps {
-  value: string | Uint8Array
-  size?: number
-  bgColor?: string
-  fgColor?: string
-  level?: 'L' | 'M' | 'Q' | 'H'
-  renderAs?: 'svg' | 'canvas'
-}
 
 const QRCode = ({ level = 'H', renderAs = 'svg', value }: QRCodeProps) => (
   <ResponsiveSvgWrapper>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1727,10 +1727,10 @@
   resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-1.2.0.tgz#e2721f2f009d5f5d333baf9d7e162960623f7157"
   integrity sha512-TlCfcO2agFz9qS1vg3JqLGuTuxG46qD5HSMiLs3PooQ6mOMifEXOzEYkY/cv71xaSCxSy621DKfB/ilYX6TNwA==
 
-"@votingworks/qrcode.react@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/qrcode.react/-/qrcode.react-1.0.0.tgz#4084776c900df8e9ba7694268f7532378b79eef1"
-  integrity sha512-IGq6HDO6zdWA6bnvLQsFUP8JJLdCz3QYFJFPa6GKEoHijgCMgxFJVMzcWJ27ILboESJjRlqqwbaW4AmAdAAb+A==
+"@votingworks/qrcode.react@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@votingworks/qrcode.react/-/qrcode.react-1.0.1.tgz#fc217fa660deb720cd7d46d72934a418790ef0f2"
+  integrity sha512-7FqtqYVlsG7LhYkPifNkSOQiJNzqGbdQB6vPC+EXmbBaWkd9rvKX3hTMW8ExLsj5g8OTEi3EKMj2Tkq0w9vuhQ==
   dependencies:
     loose-envify "^1.4.0"
     prop-types "^15.6.0"


### PR DESCRIPTION
I updated `qrcode.react` to export the types so we could use them here. I also rebased on top of zpao/master which mostly just got us this: https://github.com/zpao/qrcode.react/pull/81. We probably won't use it, but it's nice to have.