### PR TITLE
fix: export one copy of each ballot PDF

### DIFF
--- a/client/src/AppRoot.tsx
+++ b/client/src/AppRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import 'normalize.css'
 import ObjectHash from 'object-hash'
@@ -25,11 +25,13 @@ export const electionStorageKey = 'election'
 
 const AppRoot = ({ storage }: Props) => {
   const getElection = () => storage.get(electionStorageKey)
+
   const storageElection = getElection()
   const [electionHash, setElectionHash] = useState(
     storageElection ? ObjectHash(storageElection) : ''
   )
-  const [election, setElection] = useState<OptionalElection>(storageElection)
+  const [election, setElection] = useState<OptionalElection>(getElection())
+  const printBallotRef = useRef<HTMLDivElement>(null)
 
   const saveElection: SaveElection = (electionConfigFile) => {
     const election = electionConfigFile
@@ -48,10 +50,14 @@ const AppRoot = ({ storage }: Props) => {
         election,
         electionHash,
         saveElection,
+        printBallotRef,
       }}
     >
       {election ? (
-        <ElectionManager />
+        <React.Fragment>
+          <ElectionManager />
+          <div ref={printBallotRef} />
+        </React.Fragment>
       ) : (
         <UnconfiguredApp election={election} saveElection={saveElection} />
       )}

--- a/client/src/components/ElectionManager.tsx
+++ b/client/src/components/ElectionManager.tsx
@@ -21,37 +21,34 @@ export const routerPaths = {
 }
 
 const ElectionManager = () => (
-  <React.Fragment>
-    <Screen>
-      <Main padded>
-        <Switch>
-          <Route
-            path={routerPaths.electionConfig}
-            component={ElectionConfigScreen}
-          />
-          <Route
-            path={routerPaths.ballotsList}
-            exact
-            component={BallotListScreen}
-          />
-          <Route
-            path={routerPaths.ballotsView({
-              ballotStyleId: ':ballotStyleId',
-              precinctId: ':precinctId',
-            })}
-            component={BallotScreen}
-          />
-          <Route
-            path={routerPaths.export}
-            component={ExportElectionBallotPackageScreen}
-          />
-          <Route component={BallotListScreen} />
-        </Switch>
-      </Main>
-      <Navigation />
-    </Screen>
-    <div id="print-ballot" />
-  </React.Fragment>
+  <Screen>
+    <Main padded>
+      <Switch>
+        <Route
+          path={routerPaths.electionConfig}
+          component={ElectionConfigScreen}
+        />
+        <Route
+          path={routerPaths.ballotsList}
+          exact
+          component={BallotListScreen}
+        />
+        <Route
+          path={routerPaths.ballotsView({
+            ballotStyleId: ':ballotStyleId',
+            precinctId: ':precinctId',
+          })}
+          component={BallotScreen}
+        />
+        <Route
+          path={routerPaths.export}
+          component={ExportElectionBallotPackageScreen}
+        />
+        <Route component={BallotListScreen} />
+      </Switch>
+    </Main>
+    <Navigation />
+  </Screen>
 )
 
 export default ElectionManager

--- a/client/src/contexts/AppContext.ts
+++ b/client/src/contexts/AppContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react'
+import { createContext, RefObject } from 'react'
 import { OptionalElection } from '@votingworks/ballot-encoder'
 import { SaveElection } from '../config/types'
 
@@ -6,12 +6,14 @@ interface AppContextInterface {
   election: OptionalElection
   electionHash: string
   saveElection: SaveElection
+  printBallotRef?: RefObject<HTMLElement>
 }
 
 const appContext: AppContextInterface = {
   election: undefined,
   electionHash: '',
   saveElection: () => undefined,
+  printBallotRef: undefined,
 }
 
 const AppContext = createContext(appContext)

--- a/client/src/screens/ExportElectionBallotPackageScreen.tsx
+++ b/client/src/screens/ExportElectionBallotPackageScreen.tsx
@@ -1,136 +1,226 @@
-import React, { useContext, useEffect, useState } from 'react'
 import { Election } from '@votingworks/ballot-encoder'
-
-import AppContext from '../contexts/AppContext'
-
-import {
-  getBallotStylesDataByStyle,
-  getPrecinctById,
-  getBallotFileName,
-} from '../utils/election'
-import DownloadableArchive from '../utils/DownloadableArchive'
-
+import React, { useCallback, useContext, useEffect, useState } from 'react'
+import HandMarkedPaperBallot from '../components/HandMarkedPaperBallot'
 import { MainChild } from '../components/Main'
 import { Monospace } from '../components/Text'
-import HandMarkedPaperBallot from '../components/HandMarkedPaperBallot'
+import AppContext from '../contexts/AppContext'
+import DownloadableArchive from '../utils/DownloadableArchive'
+import {
+  getBallotFileName,
+  getBallotStylesDataByStyle,
+  getPrecinctById,
+} from '../utils/election'
+
+type State = Init | ArchiveBegin | RenderBallot | ArchiveEnd | Done | Failed
+
+interface Init {
+  type: 'Init'
+}
+
+interface ArchiveBegin {
+  type: 'ArchiveBegin'
+  archive: DownloadableArchive
+}
+
+interface RenderBallot {
+  type: 'RenderBallot'
+  archive: DownloadableArchive
+  ballotIndex: number
+  ballotCount: number
+}
+
+interface ArchiveEnd {
+  type: 'ArchiveEnd'
+  archive: DownloadableArchive
+  ballotCount: number
+}
+
+interface Done {
+  type: 'Done'
+  ballotCount: number
+}
+
+interface Failed {
+  type: 'Failed'
+  message: string
+}
 
 const ExportElectionBallotPackageScreen = () => {
   const { election: e, electionHash } = useContext(AppContext)
   const election = e as Election
-
   const ballotStylesDataByStyle = getBallotStylesDataByStyle(election)
-  const [ballotIndex, setBallotIndex] = useState(0)
-  const ballot = ballotStylesDataByStyle[ballotIndex]
-  const { contestIds, precinctId, ballotStyleId } = ballot
-  const ballotCount = ballotStylesDataByStyle.length
-  const [isChoosingFile, setIsChoosingFile] = useState(true)
-  const [downloadFailed, setDownloadFailed] = useState(false)
-  const [downloadComplete, setDownloadComplete] = useState(false)
-  const [archive] = useState(new DownloadableArchive())
-  const precinctName = getPrecinctById({
-    election,
-    precinctId: ballot.precinctId,
-  })!.name
 
+  const [state, setState] = useState<State>({ type: 'Init' })
+
+  /**
+   * Execute side effects for the current state and, when ready, transition to
+   * the next state.
+   */
   useEffect(() => {
-    const saveBallotPDF = async () => {
-      const name = getBallotFileName({
-        ballotStyleId,
-        election,
-        electionHash,
-        precinctId,
-      })
-      const data = await kiosk!.printToPDF()
-      await archive.file(name, Buffer.from(data))
-      setBallotIndex((ballotIndex) => ballotIndex + 1)
-    }
-
-    if (!downloadFailed && isChoosingFile) {
-      ;(async () => {
-        try {
-          await archive.begin()
-          await archive.file(
-            'election.json',
-            JSON.stringify(election, undefined, 2)
-          )
-          setIsChoosingFile(false)
-          setDownloadFailed(false)
-        } catch {
-          setIsChoosingFile(false)
-          setDownloadFailed(true)
+    ;(async () => {
+      switch (state.type) {
+        case 'Init': {
+          setState({
+            type: 'ArchiveBegin',
+            archive: new DownloadableArchive(),
+          })
+          break
         }
-      })()
-    } else if (ballotIndex + 1 < ballotCount) {
-      saveBallotPDF()
-    } else {
-      ;(async () => {
-        await archive.end()
-        setDownloadComplete(true)
-      })()
+
+        case 'ArchiveBegin': {
+          try {
+            await state.archive.begin()
+
+            setState({
+              type: 'RenderBallot',
+              archive: state.archive,
+              ballotIndex: 0,
+              ballotCount: ballotStylesDataByStyle.length,
+            })
+          } catch (error) {
+            setState({
+              type: 'Failed',
+              message: error.message,
+            })
+          }
+          break
+        }
+
+        case 'ArchiveEnd': {
+          await state.archive.end()
+          setState({ type: 'Done', ballotCount: state.ballotCount })
+        }
+      }
+    })()
+  }, [state, ballotStylesDataByStyle.length])
+
+  /**
+   * Callback from `HandMarkedPaperBallot` to let us know the preview has been
+   * rendered. Once this happens, we generate a PDF and move on to the next one
+   * or finish up if that was the last one.
+   */
+  const onRendered = useCallback(async () => {
+    if (state.type !== 'RenderBallot') {
+      throw new Error(
+        `unexpected state '${state.type}' found during onRendered callback`
+      )
     }
-  }, [
-    archive,
-    ballotCount,
-    ballotIndex,
-    ballotStyleId,
-    downloadFailed,
-    election,
-    electionHash,
-    isChoosingFile,
-    precinctId,
-    setDownloadFailed,
-    setIsChoosingFile,
-  ])
 
-  if (downloadFailed) {
-    return (
-      <MainChild>
-        <h1>Download Failed</h1>
-      </MainChild>
-    )
+    const { ballotStyleId, precinctId } = ballotStylesDataByStyle[
+      state.ballotIndex
+    ]
+    const name = getBallotFileName({
+      ballotStyleId,
+      election,
+      electionHash,
+      precinctId,
+    })
+    const data = await kiosk!.printToPDF()
+    await state.archive.file(name, Buffer.from(data))
+
+    if (state.ballotIndex + 1 === state.ballotCount) {
+      setState({
+        type: 'ArchiveEnd',
+        archive: state.archive,
+        ballotCount: state.ballotCount,
+      })
+    } else {
+      setState({ ...state, ballotIndex: state.ballotIndex + 1 })
+    }
+  }, [state, ballotStylesDataByStyle, election, electionHash])
+
+  switch (state.type) {
+    case 'Init': {
+      return (
+        <MainChild>
+          <h1>Initializing Download…</h1>
+        </MainChild>
+      )
+    }
+
+    case 'ArchiveBegin': {
+      return (
+        <MainChild>
+          <h1>Downloading</h1>
+          <p>Choose where to save the package…</p>
+        </MainChild>
+      )
+    }
+
+    case 'RenderBallot': {
+      const { ballotIndex, ballotCount } = state
+      const { ballotStyleId, precinctId, contestIds } = ballotStylesDataByStyle[
+        ballotIndex
+      ]
+      const precinctName = getPrecinctById({ election, precinctId })!.name
+
+      return (
+        <MainChild>
+          <h1>
+            Generating Ballot {ballotIndex + 1} of {ballotCount}
+          </h1>
+          <ul>
+            <li>
+              Ballot Style: <strong>{ballotStyleId}</strong>
+            </li>
+            <li>
+              Precinct: <strong>{precinctName}</strong>
+            </li>
+            <li>
+              Contest count: <strong>{contestIds.length}</strong>
+            </li>
+            <li>
+              Filename:{' '}
+              <Monospace>
+                {getBallotFileName({
+                  ballotStyleId,
+                  election,
+                  electionHash,
+                  precinctId,
+                })}
+              </Monospace>
+            </li>
+          </ul>
+          <HandMarkedPaperBallot
+            ballotStyleId={ballotStyleId}
+            election={election}
+            precinctId={precinctId}
+            onRendered={onRendered}
+          />
+        </MainChild>
+      )
+    }
+
+    case 'ArchiveEnd': {
+      return (
+        <MainChild>
+          <h1>Finishing Download</h1>
+          <p>Rendered {state.ballotCount} ballot(s), closing zip file.</p>
+        </MainChild>
+      )
+    }
+
+    case 'Done': {
+      return (
+        <MainChild>
+          <h1>Download Complete</h1>
+          <p>Rendered {state.ballotCount} ballot(s).</p>
+        </MainChild>
+      )
+    }
+
+    case 'Failed': {
+      return (
+        <MainChild>
+          <h1>Download Failed</h1>
+          <p>An error occurred: {state.message}.</p>
+        </MainChild>
+      )
+    }
   }
 
-  if (downloadComplete) {
-    return (
-      <MainChild>
-        <h1>Download Complete</h1>
-      </MainChild>
-    )
-  }
-  return (
-    <MainChild>
-      <h1>
-        Generating Ballot {ballotIndex + 1} of {ballotCount}
-      </h1>
-      <ul>
-        <li>
-          Ballot Style: <strong>{ballot.ballotStyleId}</strong>
-        </li>
-        <li>
-          Precinct: <strong>{precinctName}</strong>
-        </li>
-        <li>
-          Contest count: <strong>{contestIds.length}</strong>
-        </li>
-        <li>
-          Filename:{' '}
-          <Monospace>
-            {getBallotFileName({
-              ballotStyleId,
-              election,
-              electionHash,
-              precinctId,
-            })}
-          </Monospace>
-        </li>
-      </ul>
-      <HandMarkedPaperBallot
-        ballotStyleId={ballotStyleId}
-        election={election}
-        precinctId={precinctId}
-      />
-    </MainChild>
-  )
+  // @ts-ignore
+  return <MainChild>Unknown State: {state.type}</MainChild>
 }
 
 export default ExportElectionBallotPackageScreen


### PR DESCRIPTION
Because there were a lot of side effects to manage, I decided to do a basic state machine kind of thing in `ExportElectionBallotPackageScreen`. This makes it clear what data each state needs and how you get from one state to another.

Additionally, I cleaned up the screen and print ballot elements so that they no longer require IDs and just use refs.