### PR TITLE
fix: ensure there is a space after "for"

### DIFF
--- a/client/src/components/HandMarkedPaperBallot.tsx
+++ b/client/src/components/HandMarkedPaperBallot.tsx
@@ -313,8 +313,7 @@ const HandMarkedPaperBallot = ({
               <Prose maxWidth={false} compact>
                 <Text>
                   {isLiveMode ? 'Official Ballot' : 'Unofficial TEST Ballot'}{' '}
-                  for
-                  {partyPrimaryAdjective} {title}
+                  for {partyPrimaryAdjective} {title}
                 </Text>
                 <Text>
                   {county.name}, {state}


### PR DESCRIPTION
Without this, it reads e.g. "Official Ballot forDemocratic 2019 Primary".