### PR TITLE
feat: include live and test ballots in a package

### DIFF
--- a/client/src/screens/ExportElectionBallotPackageScreen.tsx
+++ b/client/src/screens/ExportElectionBallotPackageScreen.tsx
@@ -75,7 +75,7 @@ const ExportElectionBallotPackageScreen = () => {
       precinctId,
     })
     const data = await kiosk!.printToPDF()
-    const path = `${state.testMode ? 'test' : 'live'}/${name}`
+    const path = `${state.isLiveMode ? 'live' : 'test'}/${name}`
     await state.archive.file(path, Buffer.from(data))
     setState(workflow.next)
   }, [state, ballotStylesDataByStyle, election, electionHash])
@@ -99,7 +99,7 @@ const ExportElectionBallotPackageScreen = () => {
     }
 
     case 'RenderBallot': {
-      const { ballotIndex, ballotData, testMode } = state
+      const { ballotIndex, ballotData, isLiveMode } = state
       const { ballotStyleId, precinctId, contestIds } = ballotStylesDataByStyle[
         ballotIndex
       ]
@@ -137,7 +137,7 @@ const ExportElectionBallotPackageScreen = () => {
             election={election}
             precinctId={precinctId}
             onRendered={onRendered}
-            isLiveMode={!testMode}
+            isLiveMode={isLiveMode}
           />
         </NavigationScreen>
       )

--- a/client/src/workflows/ExportElectionBallotPackageWorkflow.test.ts
+++ b/client/src/workflows/ExportElectionBallotPackageWorkflow.test.ts
@@ -1,0 +1,123 @@
+import { init, next, error } from './ExportElectionBallotPackageWorkflow'
+import { electionSample } from '@votingworks/ballot-encoder'
+import DownloadableArchive from '../utils/DownloadableArchive'
+
+test('initializes with an Election', () => {
+  expect(init(electionSample).type).toEqual('Init')
+})
+
+test('advances from Init to ArchiveBegin', () => {
+  const state = init(electionSample)
+  expect(next(state).type).toEqual('ArchiveBegin')
+})
+
+test('advances from ArchiveBegin to RenderBallot with the first ballot in live mode', () => {
+  expect(
+    next({
+      type: 'ArchiveBegin',
+      election: electionSample,
+      archive: new DownloadableArchive(),
+    })
+  ).toEqual(
+    expect.objectContaining({
+      type: 'RenderBallot',
+      ballotIndex: 0,
+      testMode: false,
+    })
+  )
+})
+
+test('advances from RenderBallot by rendering a test ballot after a live one', () => {
+  expect(
+    next({
+      type: 'RenderBallot',
+      archive: new DownloadableArchive(),
+      ballotData: [
+        { ballotStyleId: '77', precinctId: '42', contestIds: ['1'] },
+      ],
+      ballotIndex: 0,
+      testMode: false,
+    })
+  ).toEqual({
+    type: 'RenderBallot',
+    archive: new DownloadableArchive(),
+    ballotData: [{ ballotStyleId: '77', precinctId: '42', contestIds: ['1'] }],
+    ballotIndex: 0,
+    testMode: true,
+  })
+})
+
+test('advances from RenderBallot by rendering the next page after both live and test are rendered', () => {
+  expect(
+    next({
+      type: 'RenderBallot',
+      archive: new DownloadableArchive(),
+      ballotData: [
+        { ballotStyleId: '77', precinctId: '42', contestIds: ['1'] },
+        { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
+      ],
+      ballotIndex: 0,
+      testMode: true,
+    })
+  ).toEqual(
+    expect.objectContaining({
+      type: 'RenderBallot',
+      ballotIndex: 1,
+      testMode: false,
+    })
+  )
+})
+
+test('advances from RenderBallot to ArchiveEnd after the last page', () => {
+  expect(
+    next({
+      type: 'RenderBallot',
+      archive: new DownloadableArchive(),
+      ballotData: [
+        { ballotStyleId: '77', precinctId: '42', contestIds: ['1'] },
+        { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
+      ],
+      ballotIndex: 1,
+      testMode: true,
+    })
+  ).toEqual(
+    expect.objectContaining({
+      type: 'ArchiveEnd',
+      ballotCount: 2,
+    })
+  )
+})
+
+test('advances from ArchiveEnd to Done', () => {
+  expect(
+    next({
+      type: 'ArchiveEnd',
+      archive: new DownloadableArchive(),
+      ballotCount: 2,
+    })
+  ).toEqual({
+    type: 'Done',
+    ballotCount: 2,
+  })
+})
+
+test('advances to Failed on render error', () => {
+  expect(
+    error(
+      {
+        type: 'RenderBallot',
+        archive: new DownloadableArchive(),
+        ballotData: [
+          { ballotStyleId: '77', precinctId: '42', contestIds: ['1'] },
+          { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
+        ],
+        ballotIndex: 1,
+        testMode: true,
+      },
+      new Error('something happened!')
+    )
+  ).toEqual({
+    type: 'Failed',
+    message: 'something happened!',
+  })
+})

--- a/client/src/workflows/ExportElectionBallotPackageWorkflow.test.ts
+++ b/client/src/workflows/ExportElectionBallotPackageWorkflow.test.ts
@@ -22,7 +22,7 @@ test('advances from ArchiveBegin to RenderBallot with the first ballot in live m
     expect.objectContaining({
       type: 'RenderBallot',
       ballotIndex: 0,
-      testMode: false,
+      isLiveMode: true,
     })
   )
 })
@@ -36,14 +36,14 @@ test('advances from RenderBallot by rendering a test ballot after a live one', (
         { ballotStyleId: '77', precinctId: '42', contestIds: ['1'] },
       ],
       ballotIndex: 0,
-      testMode: false,
+      isLiveMode: true,
     })
   ).toEqual({
     type: 'RenderBallot',
     archive: new DownloadableArchive(),
     ballotData: [{ ballotStyleId: '77', precinctId: '42', contestIds: ['1'] }],
     ballotIndex: 0,
-    testMode: true,
+    isLiveMode: false,
   })
 })
 
@@ -57,13 +57,13 @@ test('advances from RenderBallot by rendering the next page after both live and 
         { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
       ],
       ballotIndex: 0,
-      testMode: true,
+      isLiveMode: false,
     })
   ).toEqual(
     expect.objectContaining({
       type: 'RenderBallot',
       ballotIndex: 1,
-      testMode: false,
+      isLiveMode: true,
     })
   )
 })
@@ -78,7 +78,7 @@ test('advances from RenderBallot to ArchiveEnd after the last page', () => {
         { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
       ],
       ballotIndex: 1,
-      testMode: true,
+      isLiveMode: false,
     })
   ).toEqual(
     expect.objectContaining({
@@ -112,7 +112,7 @@ test('advances to Failed on render error', () => {
           { ballotStyleId: '77', precinctId: '42', contestIds: ['2'] },
         ],
         ballotIndex: 1,
-        testMode: true,
+        isLiveMode: false,
       },
       new Error('something happened!')
     )

--- a/client/src/workflows/ExportElectionBallotPackageWorkflow.ts
+++ b/client/src/workflows/ExportElectionBallotPackageWorkflow.ts
@@ -31,7 +31,7 @@ export interface RenderBallot {
   archive: DownloadableArchive
   ballotData: BallotStyleData[]
   ballotIndex: number
-  testMode: boolean
+  isLiveMode: boolean
 }
 
 export interface ArchiveEnd {
@@ -75,15 +75,15 @@ export function next(state: State): State {
         archive: state.archive,
         ballotData: getBallotStylesDataByStyle(state.election),
         ballotIndex: 0,
-        testMode: false,
+        isLiveMode: true,
       }
 
     case 'RenderBallot':
-      if (!state.testMode) {
+      if (state.isLiveMode) {
         // Render the same page, but in test mode.
         return {
           ...state,
-          testMode: !state.testMode,
+          isLiveMode: !state.isLiveMode,
         }
       }
 
@@ -97,7 +97,7 @@ export function next(state: State): State {
 
       return {
         ...state,
-        testMode: !state.testMode,
+        isLiveMode: !state.isLiveMode,
         ballotIndex: state.ballotIndex + 1,
       }
 

--- a/client/src/workflows/ExportElectionBallotPackageWorkflow.ts
+++ b/client/src/workflows/ExportElectionBallotPackageWorkflow.ts
@@ -1,0 +1,120 @@
+import DownloadableArchive from '../utils/DownloadableArchive'
+import {
+  Election,
+  BallotStyle,
+  Contest,
+  Precinct,
+} from '@votingworks/ballot-encoder'
+import { getBallotStylesDataByStyle } from '../utils/election'
+
+export type State =
+  | Init
+  | ArchiveBegin
+  | RenderBallot
+  | ArchiveEnd
+  | Done
+  | Failed
+
+export interface Init {
+  type: 'Init'
+  election: Election
+}
+
+export interface ArchiveBegin {
+  type: 'ArchiveBegin'
+  election: Election
+  archive: DownloadableArchive
+}
+
+export interface RenderBallot {
+  type: 'RenderBallot'
+  archive: DownloadableArchive
+  ballotData: BallotStyleData[]
+  ballotIndex: number
+  testMode: boolean
+}
+
+export interface ArchiveEnd {
+  type: 'ArchiveEnd'
+  archive: DownloadableArchive
+  ballotCount: number
+}
+
+export interface Done {
+  type: 'Done'
+  ballotCount: number
+}
+
+export interface Failed {
+  type: 'Failed'
+  message: string
+}
+
+export interface BallotStyleData {
+  ballotStyleId: BallotStyle['id']
+  contestIds: Contest['id'][]
+  precinctId: Precinct['id']
+}
+
+export function init(election: Election): Init {
+  return { type: 'Init', election }
+}
+
+export function next(state: State): State {
+  switch (state.type) {
+    case 'Init':
+      return {
+        type: 'ArchiveBegin',
+        election: state.election,
+        archive: new DownloadableArchive(),
+      }
+
+    case 'ArchiveBegin':
+      return {
+        type: 'RenderBallot',
+        archive: state.archive,
+        ballotData: getBallotStylesDataByStyle(state.election),
+        ballotIndex: 0,
+        testMode: false,
+      }
+
+    case 'RenderBallot':
+      if (!state.testMode) {
+        // Render the same page, but in test mode.
+        return {
+          ...state,
+          testMode: !state.testMode,
+        }
+      }
+
+      if (state.ballotIndex + 1 === state.ballotData.length) {
+        return {
+          type: 'ArchiveEnd',
+          archive: state.archive,
+          ballotCount: state.ballotData.length,
+        }
+      }
+
+      return {
+        ...state,
+        testMode: !state.testMode,
+        ballotIndex: state.ballotIndex + 1,
+      }
+
+    case 'ArchiveEnd':
+      return {
+        type: 'Done',
+        ballotCount: state.ballotCount,
+      }
+
+    default:
+      throw new Error(`unknown state type: '${state.type}'`)
+  }
+}
+
+export function error(state: State, error: Error): State {
+  return {
+    type: 'Failed',
+    message: error.message,
+  }
+}


### PR DESCRIPTION
This refactors the state transition code into a separate module, which I'm calling a "workflow", to make it easier to test.

Refs https://github.com/votingworks/vxmail/issues/32