### PR TITLE
bug: missing default namespace

### DIFF
--- a/client/src/components/HandMarkedPaperBallot.tsx
+++ b/client/src/components/HandMarkedPaperBallot.tsx
@@ -393,9 +393,13 @@ const HandMarkedPaperBallot = ({
   const localeElection: OptionalElection = secondaryLocaleCode
     ? withLocale(election, secondaryLocaleCode)
     : undefined
-  i18n.addResources(DEFAULT_LOCALE, '', election.ballotStrings)
+  i18n.addResources(DEFAULT_LOCALE, 'translation', election.ballotStrings)
   if (localeElection) {
-    i18n.addResources(secondaryLocaleCode, '', localeElection.ballotStrings)
+    i18n.addResources(
+      secondaryLocaleCode,
+      'translation',
+      localeElection.ballotStrings
+    )
   }
   const primaryPartyName = getPartyFullNameFromBallotStyle({
     ballotStyleId,


### PR DESCRIPTION
In an effort to move the "default translations" feature out of this branch, I left out a fix. 