### PR TITLE
fix date to be in proper timezone

### DIFF
--- a/client/src/data/defaultElection.json
+++ b/client/src/data/defaultElection.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "date": "2020-11-03",
+  "date": "2020-11-03T00:00:00-08:00",
   "_lang": {
     "es-US": {
       "title": "Eleccion General",

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -10,5 +10,4 @@ const proxy = require('http-proxy-middleware')
 
 module.exports = function (app) {
   app.use(proxy('/convert', { target: 'http://localhost:3003/' }))
-  app.use(proxy('/usbstick', { target: 'http://localhost:3004/' }))
 }


### PR DESCRIPTION
also remove proxy line that I forgot to remove in last PR.

Regarding the date: it would be nice if we could just deal with date data structures, but JavaScript really wants a whole timestamp, so easiest change here is making sure the date field is a fully timezoned ISO-8601 string.

Fixes https://github.com/votingworks/vxmail/issues/85