### PR TITLE
test: add test to ensure digits can be in file names

### DIFF
--- a/client/src/utils/election.test.ts
+++ b/client/src/utils/election.test.ts
@@ -1,0 +1,17 @@
+import { getBallotPath } from './election'
+import { electionSample } from '@votingworks/ballot-encoder'
+
+test('getBallotPath allows digits in file names', () => {
+  expect(
+    getBallotPath({
+      election: electionSample,
+      electionHash: 'd34db33f',
+      ballotStyleId: '77',
+      precinctId: '21',
+      locales: { primary: 'en-US' },
+      isLiveMode: true,
+    })
+  ).toEqual(
+    'live/election-d34db33f-precinct-north-springfield-id-21-style-77-English.pdf'
+  )
+})

--- a/client/src/utils/election.ts
+++ b/client/src/utils/election.ts
@@ -124,5 +124,5 @@ export const getBallotPath = ({
     precinctName
   )}-id-${precinctId}-style-${ballotStyleId}-${getHumanBallotLanguageFormat(
     locales
-  )?.replace(/[^a-z]+/gi, '-')}.pdf`
+  ).replace(/[^a-z]+/gi, '-')}.pdf`
 }


### PR DESCRIPTION
Beau pointed out what appeared to be an issue with the file name generation code at https://github.com/votingworks/election-manager/pull/41/files#r450598526. This turned out to not be a problem as it only replaces digits with dashes in the human-readable language names. Still, I was here so I added a test and realized that I no longer needed an optional chain property access before calling `replace`.