### PR TITLE
don't count a vote the moment it's over or empty

### DIFF
--- a/client/src/lib/votecounting.ts
+++ b/client/src/lib/votecounting.ts
@@ -2,6 +2,7 @@ import {
   Party,
   YesNoVote,
   Candidate,
+  CandidateContest,
   CandidateVote,
   Election,
   VotesDict,
@@ -150,13 +151,15 @@ export function tallyVotesByContest({
         return
       }
 
+      // overvotes & undervotes
+      const seats =
+        contest.type === 'yesno' ? 1 : (contest as CandidateContest).seats
+      if (selected.length > seats || selected.length === 0) {
+        return
+      }
+
       if (contest.type === 'yesno') {
         const optionTally = find(tallies, (optionTally) => {
-          // console.log({
-          //   contest,
-          //   option: (optionTally as YesNoContestOptionTally).option[0],
-          //   selected: selected[0],
-          // })
           return (
             (optionTally as YesNoContestOptionTally).option[0] === selected[0]
           )

--- a/client/src/lib/votecounting.ts
+++ b/client/src/lib/votecounting.ts
@@ -24,7 +24,7 @@ import find from '../utils/find'
 
 // the generic write-in candidate to keep count
 const writeInCandidate: Candidate = {
-  id: 'writein',
+  id: '__write-in',
   name: 'Write-In',
   isWriteIn: true,
 }

--- a/client/src/lib/votecounting.ts
+++ b/client/src/lib/votecounting.ts
@@ -152,9 +152,9 @@ export function tallyVotesByContest({
       }
 
       // overvotes & undervotes
-      const seats =
+      const maxSelectable =
         contest.type === 'yesno' ? 1 : (contest as CandidateContest).seats
-      if (selected.length > seats || selected.length === 0) {
+      if (selected.length > maxSelectable || selected.length === 0) {
         return
       }
 


### PR DESCRIPTION

As soon as we know it's an overvote or undervote, stop counting it, given that the overvote/undervote computation is happening separately anyways.

Also, fix the expected write-in candidate ID, it's `__write-in`.