### PR TITLE
More efficient with large CVRs

### DIFF
--- a/client/src/AppRoot.tsx
+++ b/client/src/AppRoot.tsx
@@ -81,13 +81,15 @@ const AppRoot = ({ storage }: Props) => {
     newCVRFiles = CastVoteRecordFiles.empty
   ) => {
     setCastVoteRecordFiles(newCVRFiles)
+    /*
+    // TURNING OFF STORAGE FOR NOW
     if (newCVRFiles === CastVoteRecordFiles.empty) {
       storage.remove(cvrsStorageKey)
       storage.remove(isOfficialResultsKey)
       setIsOfficialResults(false)
     } else {
       storage.set(cvrsStorageKey, newCVRFiles.export())
-    }
+    } */
   }
 
   const [voteCounts, setVoteCounts] = useState<OptionalVoteCounts>()

--- a/client/src/lib/votecounting.ts
+++ b/client/src/lib/votecounting.ts
@@ -451,7 +451,7 @@ export const getOvervotePairTallies = ({
 type CVRCategorizer = (cvr: CastVoteRecord) => string
 
 interface VoteCountsByCategoryParams {
-  castVoteRecords: CastVoteRecord[]
+  castVoteRecords: CastVoteRecord[][]
   categorizers: Dictionary<CVRCategorizer>
 }
 
@@ -464,19 +464,20 @@ export const voteCountsByCategory = ({
   castVoteRecords,
   categorizers,
 }: VoteCountsByCategoryParams): Dictionary<Dictionary<number>> => {
-  console.log('COUNTING VOTES')
   const counts: Dictionary<Dictionary<number>> = {}
   for (const category in categorizers) {
     counts[category] = {}
   }
 
-  for (const cvr of castVoteRecords) {
-    for (const category in categorizers) {
-      const categorizer = categorizers[category]
-      const categoryValue = categorizer!(cvr)
-      const count = counts[category]!
+  for (const cvrArray of castVoteRecords) {
+    for (const cvr of cvrArray) {
+      for (const category in categorizers) {
+        const categorizer = categorizers[category]
+        const categoryValue = categorizer!(cvr)
+        const count = counts[category]!
 
-      count[categoryValue] = (count[categoryValue] || 0) + 1
+        count[categoryValue] = (count[categoryValue] || 0) + 1
+      }
     }
   }
 

--- a/client/src/screens/OvervoteCombinationReportScreen.tsx
+++ b/client/src/screens/OvervoteCombinationReportScreen.tsx
@@ -2,8 +2,6 @@ import React, { useContext } from 'react'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 
-import { CastVoteRecord } from '../config/types'
-
 import NavigationScreen from '../components/NavigationScreen'
 import PrintButton from '../components/PrintButton'
 import LinkButton from '../components/LinkButton'

--- a/client/src/screens/OvervoteCombinationReportScreen.tsx
+++ b/client/src/screens/OvervoteCombinationReportScreen.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from 'react'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 
+import { CastVoteRecord } from '../config/types'
+
 import NavigationScreen from '../components/NavigationScreen'
 import PrintButton from '../components/PrintButton'
 import LinkButton from '../components/LinkButton'
@@ -48,9 +50,12 @@ const PairsReportScreen = () => {
   )
   const election = e!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
+  const castVoteRecords = ([] as CastVoteRecord[]).concat(
+    ...castVoteRecordFiles.castVoteRecords
+  )
   const overvotePairTallies = getOvervotePairTallies({
     election,
-    castVoteRecords: castVoteRecordFiles.castVoteRecords,
+    castVoteRecords,
   })
 
   const electionDate = localeWeedkayAndDate.format(new Date(election.date))
@@ -58,7 +63,7 @@ const PairsReportScreen = () => {
 
   const contestTallyMeta = getContestTallyMeta({
     election,
-    castVoteRecords: castVoteRecordFiles.castVoteRecords,
+    castVoteRecords,
   })
 
   const reportHeader = (

--- a/client/src/screens/OvervoteCombinationReportScreen.tsx
+++ b/client/src/screens/OvervoteCombinationReportScreen.tsx
@@ -50,9 +50,7 @@ const PairsReportScreen = () => {
   )
   const election = e!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
-  const castVoteRecords = ([] as CastVoteRecord[]).concat(
-    ...castVoteRecordFiles.castVoteRecords
-  )
+  const castVoteRecords = castVoteRecordFiles.castVoteRecords.flat(1)
   const overvotePairTallies = getOvervotePairTallies({
     election,
     castVoteRecords,

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { useParams, useHistory } from 'react-router-dom'
@@ -37,11 +37,38 @@ const TallyHeader = styled.div`
 
 const TallyReportScreen = () => {
   const history = useHistory()
+
   const { precinctId } = useParams<PrecinctReportScreenProps>()
   const { scannerId } = useParams<ScannerReportScreenProps>()
   const { castVoteRecordFiles, election: e, isOfficialResults } = useContext(
     AppContext
   )
+
+  // the point of this state and effect is to show a loading screen
+  // and almost immediately trigger removing the loading screen,
+  // which will then trigger the computation of the tally.
+  //
+  // because the computation takes a while and blocks the main thread
+  // (which we should fix, of course), the loading screen effectively
+  // stays on the screen as long as it takes to prepare the report.
+  const [isLoading, setIsLoading] = useState(true)
+  useEffect(() => {
+    window.setTimeout(() => {
+      setIsLoading(false)
+    }, 100)
+  })
+
+  if (isLoading) {
+    return (
+      <NavigationScreen mainChildCenter>
+        <Prose textCenter>
+          <h1>Building Tabulation Report...</h1>
+          <p>This may take a few seconds.</p>
+        </Prose>
+      </NavigationScreen>
+    )
+  }
+
   const election = e!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
 

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -7,7 +7,6 @@ import find from '../utils/find'
 import { fullTallyVotes, getContestTallyMeta } from '../lib/votecounting'
 
 import {
-  CastVoteRecord,
   PrecinctReportScreenProps,
   ScannerReportScreenProps,
 } from '../config/types'
@@ -146,7 +145,9 @@ const TallyReportScreen = () => {
           </p>
           {window.kiosk && (
             <p>
-              <Button onPress={saveAsPDF}>Save {statusPrefix} Tally Report as PDF</Button>
+              <Button onPress={saveAsPDF}>
+                Save {statusPrefix} Tally Report as PDF
+              </Button>
             </p>
           )}
           <p>

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -7,6 +7,7 @@ import find from '../utils/find'
 import { fullTallyVotes, getContestTallyMeta } from '../lib/votecounting'
 
 import {
+  CastVoteRecord,
   PrecinctReportScreenProps,
   ScannerReportScreenProps,
 } from '../config/types'
@@ -44,18 +45,22 @@ const TallyReportScreen = () => {
   const election = e!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
 
-  if (castVoteRecordFiles.castVoteRecords.length === 0) {
+  const castVoteRecords = ([] as CastVoteRecord[]).concat(
+    ...castVoteRecordFiles.castVoteRecords
+  )
+
+  if (castVoteRecords.length === 0) {
     history.replace(routerPaths.tally)
   }
 
   const fullElectionTally = fullTallyVotes({
     election,
-    castVoteRecords: castVoteRecordFiles.castVoteRecords,
+    castVoteRecords,
   })
 
   const contestTallyMeta = getContestTallyMeta({
     election,
-    castVoteRecords: castVoteRecordFiles.castVoteRecords,
+    castVoteRecords,
   })
 
   const electionPrecinctTallies = Object.values(

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -72,9 +72,7 @@ const TallyReportScreen = () => {
   const election = e!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
 
-  const castVoteRecords = ([] as CastVoteRecord[]).concat(
-    ...castVoteRecordFiles.castVoteRecords
-  )
+  const castVoteRecords = castVoteRecordFiles.castVoteRecords.flat(1)
 
   if (castVoteRecords.length === 0) {
     history.replace(routerPaths.tally)

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect, useCallback } from 'react'
 import fileDownload from 'js-file-download'
 import pluralize from 'pluralize'
 
-import { InputEventFunction, CastVoteRecord } from '../config/types'
+import { InputEventFunction } from '../config/types'
 
 import {
   voteCountsByCategory,

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -77,23 +77,16 @@ const TallyScreen = () => {
     !!castVoteRecordFileList.length || !!castVoteRecordFiles.errorFile
 
   const computeVoteCounts = useCallback(() => {
-    if (hasCastVoteRecordFiles) {
-      console.log(castVoteRecordFiles)
-      setVoteCounts(
-        voteCountsByCategory({
-          castVoteRecords: castVoteRecordFiles.castVoteRecords,
-          categorizers: {
-            Precinct: CVRCategorizerByPrecinct,
-            Scanner: CVRCategorizerByScanner,
-          },
-        })
-      )
-    }
-  }, [setVoteCounts, castVoteRecordFiles, hasCastVoteRecordFiles])
-
-  useEffect(() => {
-    computeVoteCounts()
-  }, [computeVoteCounts])
+    setVoteCounts(
+      voteCountsByCategory({
+        castVoteRecords: castVoteRecordFiles.castVoteRecords,
+        categorizers: {
+          Precinct: CVRCategorizerByPrecinct,
+          Scanner: CVRCategorizerByScanner,
+        },
+      })
+    )
+  }, [setVoteCounts, castVoteRecordFiles])
 
   const processCastVoteRecordFiles: InputEventFunction = async (event) => {
     const input = event.currentTarget
@@ -102,6 +95,7 @@ const TallyScreen = () => {
     setIsLoadingCVRFile(true)
     const newCastVoteRecordFiles = await castVoteRecordFiles.addAll(files)
     saveCastVoteRecordFiles(newCastVoteRecordFiles)
+    computeVoteCounts()
     setIsLoadingCVRFile(false)
 
     input.value = ''

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect, useCallback } from 'react'
 import fileDownload from 'js-file-download'
 import pluralize from 'pluralize'
 
-import { InputEventFunction } from '../config/types'
+import { InputEventFunction, CastVoteRecord } from '../config/types'
 
 import {
   voteCountsByCategory,
@@ -78,6 +78,7 @@ const TallyScreen = () => {
 
   const computeVoteCounts = useCallback(() => {
     if (hasCastVoteRecordFiles) {
+      console.log(castVoteRecordFiles)
       setVoteCounts(
         voteCountsByCategory({
           castVoteRecords: castVoteRecordFiles.castVoteRecords,
@@ -124,7 +125,8 @@ const TallyScreen = () => {
   }, [])
 
   const exportResults = async () => {
-    const CastVoteRecordsString = castVoteRecordFiles.castVoteRecords
+    const CastVoteRecordsString = ([] as CastVoteRecord[])
+      .concat(...castVoteRecordFiles.castVoteRecords)
       .map((c) => JSON.stringify(c))
       .join('\n')
 

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -119,8 +119,8 @@ const TallyScreen = () => {
   }, [])
 
   const exportResults = async () => {
-    const CastVoteRecordsString = ([] as CastVoteRecord[])
-      .concat(...castVoteRecordFiles.castVoteRecords)
+    const CastVoteRecordsString = castVoteRecordFiles.castVoteRecords
+      .flat(1)
       .map((c) => JSON.stringify(c))
       .join('\n')
 

--- a/client/src/utils/CastVoteRecordFiles.ts
+++ b/client/src/utils/CastVoteRecordFiles.ts
@@ -31,6 +31,7 @@ function setAdd<T>(set: Set<T>, ...values: T[]): Set<T> {
  * mapAdd(map, value => value.id, { id: 3 }) // Map { 1 => { id: 1 }, 3 => { id: 3 } }
  * map                                       // Map { 1 => { id: 1 } }
  */
+/**
 function mapAdd<K, V>(
   map: Map<K, V>,
   keyfn: (value: V) => K,
@@ -43,7 +44,7 @@ function mapAdd<K, V>(
   }
 
   return result
-}
+} */
 
 /**
  * Tracks files containing cast vote records (CVRs). Has special handling for
@@ -73,7 +74,8 @@ export default class CastVoteRecordFiles {
 
   private readonly parseFailedFilenames: Set<string>
 
-  private readonly allCastVoteRecords: Map<string, CastVoteRecord>
+  // private readonly allCastVoteRecords: Map<string, CastVoteRecord>
+  private readonly allCastVoteRecords: CastVoteRecord[][]
 
   /**
    * This is your starting point for working with this class as the constructor
@@ -84,7 +86,7 @@ export default class CastVoteRecordFiles {
     new Set(),
     new Set(),
     new Set(),
-    new Map()
+    []
   )
 
   /**
@@ -96,7 +98,7 @@ export default class CastVoteRecordFiles {
     files: Set<CastVoteRecordFile>,
     duplicateFilesnames: Set<string>,
     parseFailedFilenames: Set<string>,
-    castVoteRecords: Map<string, CastVoteRecord>
+    castVoteRecords: CastVoteRecord[][]
   ) {
     this.signatures = signatures
     this.files = files
@@ -121,7 +123,7 @@ export default class CastVoteRecordFiles {
       new Set(files),
       new Set(duplicateFilenames),
       new Set(parseFailedFilenames),
-      new Map(allCastVoteRecords)
+      allCastVoteRecords
     )
   }
 
@@ -134,7 +136,7 @@ export default class CastVoteRecordFiles {
       files: [...this.files],
       duplicateFilenames: [...this.duplicateFilenames],
       parseFailedFilenames: [...this.parseFailedFilenames],
-      allCastVoteRecords: [...this.allCastVoteRecords.entries()],
+      allCastVoteRecords: this.allCastVoteRecords,
     })
   }
 
@@ -176,6 +178,9 @@ export default class CastVoteRecordFiles {
         fileCastVoteRecords.map((cvr) => cvr._precinctId)
       )
 
+      const newCastVoteRecords = this.allCastVoteRecords
+      newCastVoteRecords.push(fileCastVoteRecords)
+
       return new CastVoteRecordFiles(
         setAdd(this.signatures, signature),
         setAdd(this.files, {
@@ -185,11 +190,7 @@ export default class CastVoteRecordFiles {
         }),
         this.duplicateFilenames,
         this.parseFailedFilenames,
-        mapAdd(
-          this.allCastVoteRecords,
-          (cvr) => cvr._ballotId,
-          ...fileCastVoteRecords
-        )
+        newCastVoteRecords
       )
     } catch (error) {
       return new CastVoteRecordFiles(
@@ -226,8 +227,8 @@ export default class CastVoteRecordFiles {
   /**
    * All parsed CVRs from the added files.
    */
-  public get castVoteRecords(): CastVoteRecord[] {
-    return [...this.allCastVoteRecords.values()]
+  public get castVoteRecords(): CastVoteRecord[][] {
+    return this.allCastVoteRecords
   }
 }
 


### PR DESCRIPTION
- not keeping a map of ballot IDs anymore --> don't want to remove votes silently
- keeping an array of array of CVRs, to not copy large arrays needlessly
- recomputing voteCounts only after a new CVR file is added
- removing kiosk storage for now, will eventually look into compressing
- added a simple "building tabulation report" message since it takes a good while for large CVRs.