### PR TITLE
fix: format tally counts better

### DIFF
--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -10,6 +10,7 @@ import {
   CVRCategorizerByScanner,
 } from '../lib/votecounting'
 import ConverterClient from '../lib/ConverterClient'
+import * as format from '../utils/format'
 
 import AppContext from '../contexts/AppContext'
 
@@ -179,7 +180,7 @@ const TallyScreen = () => {
                     <TD narrow nowrap>
                       {name}
                     </TD>
-                    <TD narrow>{count}</TD>
+                    <TD narrow>{format.count(count)}</TD>
                     <TD>{getPrecinctNames(precinctIds)}</TD>
                   </tr>
                 ))}
@@ -188,9 +189,11 @@ const TallyScreen = () => {
                     Total CVRs Count
                   </TD>
                   <TD as="th" narrow>
-                    {castVoteRecordFileList.reduce(
-                      (prev, curr) => prev + curr.count,
-                      0
+                    {format.count(
+                      castVoteRecordFileList.reduce(
+                        (prev, curr) => prev + curr.count,
+                        0
+                      )
                     )}
                   </TD>
                   <TD as="th" />
@@ -278,7 +281,7 @@ const TallyScreen = () => {
                         <TD narrow nowrap>
                           {precinct.name}
                         </TD>
-                        <TD>{precinctBallotsCount}</TD>
+                        <TD>{format.count(precinctBallotsCount)}</TD>
                         <TD>
                           {!!precinctBallotsCount && (
                             <LinkButton
@@ -299,7 +302,7 @@ const TallyScreen = () => {
                     <strong>Total Ballot Count</strong>
                   </TD>
                   <TD>
-                    <strong>{totalBallots}</strong>
+                    <strong>{format.count(totalBallots)}</strong>
                   </TD>
                   <TD>
                     <LinkButton
@@ -330,13 +333,14 @@ const TallyScreen = () => {
                     })
                   )
                   .map((scannerId) => {
-                    const scannerBallotsCount = voteCounts.Scanner![scannerId]
+                    const scannerBallotsCount =
+                      voteCounts.Scanner?.[scannerId] ?? 0
                     return (
                       <tr key={scannerId}>
                         <TD narrow nowrap>
                           {scannerId}
                         </TD>
-                        <TD>{scannerBallotsCount}</TD>
+                        <TD>{format.count(scannerBallotsCount)}</TD>
                         <TD>
                           {!!scannerBallotsCount && (
                             <LinkButton
@@ -358,7 +362,7 @@ const TallyScreen = () => {
                     <strong>Total Ballot Count</strong>
                   </TD>
                   <TD>
-                    <strong>{totalBallots}</strong>
+                    <strong>{format.count(totalBallots)}</strong>
                   </TD>
                   <TD />
                 </tr>

--- a/client/src/utils/format.test.ts
+++ b/client/src/utils/format.test.ts
@@ -1,0 +1,11 @@
+import * as format from './format'
+
+test('formats counts using thousands separators as appropriate', () => {
+  expect(format.count(0)).toEqual('0')
+  expect(format.count(1)).toEqual('1')
+  expect(format.count(-1)).toEqual('-1')
+  expect(format.count(999)).toEqual('999')
+  expect(format.count(1000)).toEqual('1,000')
+  expect(format.count(-1000)).toEqual('-1,000')
+  expect(format.count(1234567890)).toEqual('1,234,567,890')
+})

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+
+const countFormatter = new Intl.NumberFormat(undefined, { useGrouping: true })
+
+/**
+ * Format integers for display as whole numbers, i.e. a count of something.
+ */
+export function count(value: number): string {
+  return countFormatter.format(value)
+}


### PR DESCRIPTION
Now with grouping separators!

<img width="585" alt="image" src="https://user-images.githubusercontent.com/1938/87085460-c761c880-c1e4-11ea-9c95-22bb3ac2506c.png">
