### PR TITLE
fix: ensure resetting CVRs actually resets things

### DIFF
--- a/client/src/config/types.ts
+++ b/client/src/config/types.ts
@@ -101,6 +101,8 @@ export interface CastVoteRecord
   _locale?: BallotLocale
 }
 
+export type CastVoteRecordLists = ReadonlyArray<ReadonlyArray<CastVoteRecord>>
+
 export interface CastVoteRecordFile {
   readonly name: string
   readonly count: number

--- a/client/src/lib/votecounting.ts
+++ b/client/src/lib/votecounting.ts
@@ -15,6 +15,7 @@ import {
   FullElectionTally,
   VotesByFilter,
   CastVoteRecord,
+  CastVoteRecordLists,
   VotesByFunction,
   Tally,
   ContestTally,
@@ -551,7 +552,7 @@ export const getOvervotePairTallies = ({
 type CVRCategorizer = (cvr: CastVoteRecord) => string
 
 interface VoteCountsByCategoryParams {
-  castVoteRecords: CastVoteRecord[][]
+  castVoteRecords: CastVoteRecordLists
   categorizers: Dictionary<CVRCategorizer>
 }
 

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect, useCallback } from 'react'
 import fileDownload from 'js-file-download'
 import pluralize from 'pluralize'
 
-import { InputEventFunction } from '../config/types'
+import { CastVoteRecordLists, InputEventFunction } from '../config/types'
 
 import {
   voteCountsByCategory,
@@ -77,17 +77,20 @@ const TallyScreen = () => {
   const hasCastVoteRecordFiles =
     !!castVoteRecordFileList.length || !!castVoteRecordFiles.lastError
 
-  const computeVoteCounts = useCallback(() => {
-    setVoteCounts(
-      voteCountsByCategory({
-        castVoteRecords: castVoteRecordFiles.castVoteRecords,
-        categorizers: {
-          Precinct: CVRCategorizerByPrecinct,
-          Scanner: CVRCategorizerByScanner,
-        },
-      })
-    )
-  }, [setVoteCounts, castVoteRecordFiles])
+  const computeVoteCounts = useCallback(
+    (castVoteRecords: CastVoteRecordLists) => {
+      setVoteCounts(
+        voteCountsByCategory({
+          castVoteRecords,
+          categorizers: {
+            Precinct: CVRCategorizerByPrecinct,
+            Scanner: CVRCategorizerByScanner,
+          },
+        })
+      )
+    },
+    [setVoteCounts]
+  )
 
   const processCastVoteRecordFiles: InputEventFunction = async (event) => {
     const input = event.currentTarget
@@ -99,7 +102,7 @@ const TallyScreen = () => {
       election
     )
     saveCastVoteRecordFiles(newCastVoteRecordFiles)
-    computeVoteCounts()
+    computeVoteCounts(newCastVoteRecordFiles.castVoteRecords)
     setIsLoadingCVRFile(false)
 
     input.value = ''

--- a/client/src/utils/CastVoteRecordFiles.test.ts
+++ b/client/src/utils/CastVoteRecordFiles.test.ts
@@ -1,0 +1,134 @@
+import { electionSample } from '@votingworks/ballot-encoder'
+import CastVoteRecordFiles from './CastVoteRecordFiles'
+import { CastVoteRecord } from '../config/types'
+
+test('starts out empty', () => {
+  const files = CastVoteRecordFiles.empty
+  expect(files.castVoteRecords).toEqual([])
+  expect(files.duplicateFiles).toEqual([])
+  expect(files.fileList).toEqual([])
+  expect(files.lastError).toBeUndefined()
+})
+
+test('can add a CVR file by creating a new instance', async () => {
+  const { empty } = CastVoteRecordFiles
+  const added = await empty.add(new File([''], 'cvrs.txt'), electionSample)
+
+  expect(added.castVoteRecords).toEqual([[]])
+  expect(added.duplicateFiles).toEqual([])
+  expect(added.fileList).toEqual([
+    { name: 'cvrs.txt', count: 0, precinctIds: [] },
+  ])
+  expect(added.lastError).toBeUndefined()
+})
+
+test('can add multiple CVR files by creating a new instance', async () => {
+  const { empty } = CastVoteRecordFiles
+  const cvr: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12',
+    _precinctId: '23',
+    _testBallot: false,
+    _scannerId: 'abc',
+  }
+  const added = await empty.addAll(
+    [new File([''], 'cvrs.txt'), new File([JSON.stringify(cvr)], 'cvrs2.txt')],
+    electionSample
+  )
+
+  expect(added.castVoteRecords).toEqual([[], [cvr]])
+  expect(added.duplicateFiles).toEqual([])
+  expect(added.fileList).toEqual([
+    { name: 'cvrs.txt', count: 0, precinctIds: [] },
+    { name: 'cvrs2.txt', count: 1, precinctIds: ['23'] },
+  ])
+  expect(added.lastError).toBeUndefined()
+})
+
+test('does not mutate the original when adding a new instance', async () => {
+  const { empty } = CastVoteRecordFiles
+  const cvr: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12',
+    _precinctId: '23',
+    _testBallot: false,
+    _scannerId: 'abc',
+  }
+  const added = await empty.add(
+    new File([JSON.stringify(cvr)], 'cvrs.txt'),
+    electionSample
+  )
+
+  expect(empty.castVoteRecords).toEqual([])
+  expect(empty.duplicateFiles).toEqual([])
+  expect(empty.fileList).toEqual([])
+  expect(empty.lastError).toBeUndefined()
+
+  expect(added.castVoteRecords).toEqual([[cvr]])
+  expect(added.duplicateFiles).toEqual([])
+  expect(added.fileList).toEqual([
+    { name: 'cvrs.txt', count: 1, precinctIds: ['23'] },
+  ])
+  expect(added.lastError).toBeUndefined()
+})
+
+test('records JSON errors', async () => {
+  const added = await CastVoteRecordFiles.empty.add(
+    new File(['{bad json'], 'cvrs.txt'),
+    electionSample
+  )
+
+  expect(added.castVoteRecords).toEqual([])
+  expect(added.duplicateFiles).toEqual([])
+  expect(added.fileList).toEqual([])
+  expect(added.lastError).toEqual({
+    filename: 'cvrs.txt',
+    message: 'Unexpected token b in JSON at position 1',
+  })
+})
+
+test('records CVR data errors', async () => {
+  const cvr: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12',
+    _precinctId: '9999',
+    _testBallot: false,
+    _scannerId: 'abc',
+  }
+  const added = await CastVoteRecordFiles.empty.add(
+    new File([JSON.stringify(cvr)], 'cvrs.txt'),
+    electionSample
+  )
+
+  expect(added.castVoteRecords).toEqual([])
+  expect(added.duplicateFiles).toEqual([])
+  expect(added.fileList).toEqual([])
+  expect(added.lastError).toEqual({
+    filename: 'cvrs.txt',
+    message: "Line 1: Precinct '9999' in CVR is not in the election definition",
+  })
+})
+
+test('records identical uploaded files', async () => {
+  const cvr: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12',
+    _precinctId: '23',
+    _testBallot: false,
+    _scannerId: 'abc',
+  }
+  const added = await CastVoteRecordFiles.empty.addAll(
+    [
+      new File([JSON.stringify(cvr)], 'cvrs.txt'),
+      new File([JSON.stringify(cvr)], 'cvrs2.txt'),
+    ],
+    electionSample
+  )
+
+  expect(added.castVoteRecords).toEqual([[cvr]])
+  expect(added.duplicateFiles).toEqual(['cvrs2.txt'])
+  expect(added.fileList).toEqual([
+    { name: 'cvrs.txt', count: 1, precinctIds: ['23'] },
+  ])
+  expect(added.lastError).toBeUndefined()
+})

--- a/client/src/utils/CastVoteRecordFiles.ts
+++ b/client/src/utils/CastVoteRecordFiles.ts
@@ -1,7 +1,11 @@
 import arrayUnique from 'array-unique'
 import { sha256 } from 'js-sha256'
 import { Election } from '@votingworks/ballot-encoder'
-import { CastVoteRecord, CastVoteRecordFile } from '../config/types'
+import {
+  CastVoteRecord,
+  CastVoteRecordFile,
+  CastVoteRecordLists,
+} from '../config/types'
 import readFileAsync from '../lib/readFileAsync'
 import { parseCVRs } from '../lib/votecounting'
 
@@ -196,9 +200,6 @@ export default class CastVoteRecordFiles {
         fileCastVoteRecords.map((cvr) => cvr._precinctId)
       )
 
-      const newCastVoteRecords = this.allCastVoteRecords
-      newCastVoteRecords.push(fileCastVoteRecords)
-
       return new CastVoteRecordFiles(
         setAdd(this.signatures, signature),
         setAdd(this.files, {
@@ -208,7 +209,7 @@ export default class CastVoteRecordFiles {
         }),
         this.duplicateFilenames,
         this.parseFailedErrors,
-        newCastVoteRecords
+        [...this.allCastVoteRecords, fileCastVoteRecords]
       )
     } catch (error) {
       return new CastVoteRecordFiles(
@@ -246,7 +247,7 @@ export default class CastVoteRecordFiles {
   /**
    * All parsed CVRs from the added files.
    */
-  public get castVoteRecords(): CastVoteRecord[][] {
+  public get castVoteRecords(): CastVoteRecordLists {
     return this.allCastVoteRecords
   }
 }


### PR DESCRIPTION
This re-introduces immutability to `CastVoteRecordFiles`, which ensures that we don't accidentally mutate the shared `empty` instance which would pollute any future CVR tallies.