### PR TITLE
make Official Initials text configurable

### DIFF
--- a/client/src/components/HandMarkedPaperBallot.tsx
+++ b/client/src/components/HandMarkedPaperBallot.tsx
@@ -502,7 +502,12 @@ const HandMarkedPaperBallot = ({
           <PageFooter>
             <OfficialInitials>
               <Text as="span" small>
-                Official’s Initials
+                <Trans
+                  i18nKey="officialInitials"
+                  tOptions={{ lng: locales.primary }}
+                >
+                  Official’s Initials
+                </Trans>
               </Text>
             </OfficialInitials>
             <PageFooterMain>


### PR DESCRIPTION
In Ms, it is clearly "Initialing Manager", and we should go with their approach, but realize it may be different from state to state.