### PR TITLE
feat: provide a default file name for ballot package

### DIFF
--- a/client/src/screens/ExportElectionBallotPackageScreen.tsx
+++ b/client/src/screens/ExportElectionBallotPackageScreen.tsx
@@ -39,7 +39,12 @@ const ExportElectionBallotPackageScreen = () => {
 
         case 'ArchiveBegin': {
           try {
-            await state.archive.begin()
+            await state.archive.begin({
+              defaultPath: `${`${election.county.name}-${election.title}`
+                .replace(/[^a-z0-9]+/gi, '-')
+                .replace(/(^-|-$)+/g, '')
+                .toLocaleLowerCase()}-${electionHash.slice(0, 10)}.zip`,
+            })
             await state.archive.file(
               'election.json',
               JSON.stringify(election, undefined, 2)
@@ -62,7 +67,7 @@ const ExportElectionBallotPackageScreen = () => {
         }
       }
     })()
-  }, [state, election])
+  }, [state, election, electionHash])
 
   /**
    * Callback from `HandMarkedPaperBallot` to let us know the preview has been

--- a/client/src/utils/DownloadableArchive.test.ts
+++ b/client/src/utils/DownloadableArchive.test.ts
@@ -53,6 +53,18 @@ test('zip file containing a file', async () => {
   expect(firstChunk.slice(0, ZIP_MAGIC_BYTES.length)).toEqual(ZIP_MAGIC_BYTES)
 })
 
+test('passes options to kiosk.saveAs', async () => {
+  const kiosk = fakeKiosk()
+  const archive = new DownloadableArchive(kiosk)
+  const fileWriter = fakeFileWriter()
+
+  kiosk.saveAs.mockResolvedValueOnce(fileWriter)
+
+  expect(fileWriter.chunks).toHaveLength(0)
+  await archive.begin({ defaultPath: 'README.md' })
+  expect(kiosk.saveAs).toHaveBeenCalledWith({ defaultPath: 'README.md' })
+})
+
 test('end() before begin()', async () => {
   const archive = new DownloadableArchive(fakeKiosk())
   await expect(archive.end()).rejects.toThrowError(

--- a/client/src/utils/DownloadableArchive.ts
+++ b/client/src/utils/DownloadableArchive.ts
@@ -17,8 +17,8 @@ export default class DownloadableArchive {
    * making this instance ready to receive files. Resolves when ready to receive
    * files.
    */
-  public async begin(): Promise<void> {
-    const fileWriter = await this.kiosk.saveAs()
+  public async begin(options?: KioskBrowser.SaveAsOptions): Promise<void> {
+    const fileWriter = await this.kiosk.saveAs(options)
 
     if (!fileWriter) {
       throw new Error('could not begin download; no file was chosen')

--- a/client/types/kiosk-browser.d.ts
+++ b/client/types/kiosk-browser.d.ts
@@ -30,6 +30,19 @@ declare namespace KioskBrowser {
     mountPoint?: string
   }
 
+  export interface SaveAsOptions {
+    title?: string
+    defaultPath?: string
+    buttonLabel?: string
+    filters?: FileFilter[]
+  }
+
+  export interface FileFilter {
+    // Docs: http://electronjs.org/docs/api/structures/file-filter
+    extensions: string[]
+    name: string
+  }
+
   export interface FileWriter {
     /**
      * Writes a chunk to the file. May be called multiple times. Data will be
@@ -61,7 +74,7 @@ declare namespace KioskBrowser {
      * Opens a Save Dialog to allow the user to choose a destination for a file.
      * Once chosen, resolves with a handle to the file to write data to it.
      */
-    saveAs(): Promise<FileWriter | undefined>
+    saveAs(options?: SaveAsOptions): Promise<FileWriter | undefined>
 
     // USB sticks
     getUsbDrives(): Promise<UsbDrive[]>
@@ -70,10 +83,10 @@ declare namespace KioskBrowser {
 
     // storage
     storage: {
-      set<K extends keyof M>(key: string, value: M[K]) : Promise<void>
-      get<K extends keyof M>(key: string) : Promise<M[K] | undefined>
-      remove(key: string) : Promise<void>
-      clear() : Promise<void>
+      set<K extends keyof M>(key: string, value: M[K]): Promise<void>
+      get<K extends keyof M>(key: string): Promise<M[K] | undefined>
+      remove(key: string): Promise<void>
+      clear(): Promise<void>
     }
   }
 }


### PR DESCRIPTION
For example, `choctaw-county-general-election-943f5233e4.zip`. Requires https://github.com/votingworks/kiosk-browser/pull/57.