### PR TITLE
fix: preserve raw configuration and hash

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 69,
-        "branches": 54.9,
+        "branches": 54.89,
         "functions": 69,
         "lines": 69
       }

--- a/client/src/components/ElectionManager.tsx
+++ b/client/src/components/ElectionManager.tsx
@@ -20,8 +20,8 @@ import DefinitionContestsScreen from '../screens/DefinitionContestsScreen'
 import PrintedBallotsReportScreen from '../screens/PrintedBallotsReportScreen'
 
 const ElectionManager = () => {
-  const { election: e } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition } = useContext(AppContext)
+  const election = electionDefinition?.election
 
   if (!election) {
     return <UnconfiguredScreen />

--- a/client/src/components/NavigationScreen.tsx
+++ b/client/src/components/NavigationScreen.tsx
@@ -25,8 +25,8 @@ const NavigationScreen = ({
   const isActiveSection = (path: string) =>
     new RegExp(`^${path}`).test(location.pathname) ? 'active-section' : ''
 
-  const { election: e } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition } = useContext(AppContext)
+  const election = electionDefinition?.election
 
   return (
     <Screen>

--- a/client/src/config/types.ts
+++ b/client/src/config/types.ts
@@ -1,9 +1,4 @@
-import {
-  OptionalElection,
-  BallotStyle,
-  Precinct,
-  Election,
-} from '@votingworks/ballot-encoder'
+import { BallotStyle, Precinct, Election } from '@votingworks/ballot-encoder'
 import { Candidate, Contest, VotesDict } from '@votingworks/ballot-encoder'
 
 // Generic
@@ -24,7 +19,13 @@ export type ButtonEventFunction = (
 ) => void | Promise<void>
 
 // Election
-export type SaveElection = (value: OptionalElection) => void
+export type SaveElection = (electionJSON?: string) => void
+
+export interface ElectionDefinition {
+  election: Election
+  electionData: string
+  electionHash: string
+}
 
 export interface BallotStyleData {
   ballotStyleId: BallotStyle['id']

--- a/client/src/contexts/AppContext.ts
+++ b/client/src/contexts/AppContext.ts
@@ -1,6 +1,6 @@
 import { createContext, RefObject } from 'react'
-import { OptionalElection } from '@votingworks/ballot-encoder'
 import {
+  ElectionDefinition,
   SaveElection,
   OptionalVoteCounts,
   PrintedBallot,
@@ -12,8 +12,7 @@ import CastVoteRecordFiles, {
 
 interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles
-  election: OptionalElection
-  electionHash: string
+  electionDefinition?: ElectionDefinition
   configuredAt: ISO8601Timestamp
   isOfficialResults: boolean
   printBallotRef?: RefObject<HTMLElement>
@@ -33,8 +32,7 @@ interface AppContextInterface {
 
 const appContext: AppContextInterface = {
   castVoteRecordFiles: CastVoteRecordFiles.empty,
-  election: undefined,
-  electionHash: '',
+  electionDefinition: undefined,
   configuredAt: '',
   isOfficialResults: false,
   printBallotRef: undefined,

--- a/client/src/screens/BallotListScreen.tsx
+++ b/client/src/screens/BallotListScreen.tsx
@@ -26,8 +26,10 @@ const Header = styled.div`
 `
 
 const BallotListScreen = () => {
-  const { election: e, printedBallots, configuredAt } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, printedBallots, configuredAt } = useContext(
+    AppContext
+  )
+  const { election } = electionDefinition!
 
   const allBallotStyles = getBallotStylesData(election)
   const ballotLists = [

--- a/client/src/screens/BallotScreen.tsx
+++ b/client/src/screens/BallotScreen.tsx
@@ -43,8 +43,8 @@ const BallotScreen = () => {
     ballotStyleId,
     localeCode: currentLocaleCode,
   } = useParams<BallotScreenProps>()
-  const { election: e, electionHash, addPrintedBallot } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, addPrintedBallot } = useContext(AppContext)
+  const { election, electionHash } = electionDefinition!
   const availableLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE)
   const locales: BallotLocale = {
     primary: DEFAULT_LOCALE,

--- a/client/src/screens/DefinitionContestsScreen.tsx
+++ b/client/src/screens/DefinitionContestsScreen.tsx
@@ -172,16 +172,22 @@ const ToggleField = ({
 )
 
 const DefinitionContestsScreen = () => {
-  const { election: e, saveElection } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, saveElection } = useContext(AppContext)
+  const { election } = electionDefinition!
   const { contestId } = useParams<{ contestId: string }>()
   const contestIndex = election.contests.findIndex((c) => c.id === contestId)
   const contest = election.contests[contestIndex]
 
   const saveContest = (newContest: AnyContest) => {
-    const newElection: Election = { ...election }
-    newElection.contests[contestIndex] = newContest
-    saveElection(newElection)
+    const newElection: Election = {
+      ...election,
+      contests: [
+        ...election.contests.slice(0, contestIndex),
+        newContest,
+        ...election.contests.slice(contestIndex + 1),
+      ],
+    }
+    saveElection(JSON.stringify(newElection))
   }
 
   const saveTextField: InputEventFunction = (event) => {

--- a/client/src/screens/DefinitionEditorScreen.tsx
+++ b/client/src/screens/DefinitionEditorScreen.tsx
@@ -33,8 +33,8 @@ const FlexTextareaWrapper = styled.div`
 `
 const DefinitionEditorScreen = () => {
   const history = useHistory()
-  const { election: e, saveElection } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, saveElection } = useContext(AppContext)
+  const { election, electionData } = electionDefinition!
   const stringifiedElection = JSON.stringify(election, undefined, 2)
   const [electionString, setElectionString] = useState(stringifiedElection)
   const [dirty, setDirty] = useState(false)
@@ -52,11 +52,11 @@ const DefinitionEditorScreen = () => {
     history.push(routerPaths.root)
   }
 
-  const parseElectionString = useCallback(() => {
+  const validateElectionDefinition = useCallback(() => {
     try {
       setError('')
-      const newElection = parseElection(JSON.parse(electionString))
-      return newElection
+      parseElection(JSON.parse(electionString))
+      return true
     } catch (error) {
       setError(error.toString())
       return false
@@ -66,10 +66,10 @@ const DefinitionEditorScreen = () => {
     setDirty(true)
     setElectionString(event.currentTarget.value)
   }
-  const hanldeSaveElection = () => {
-    const newElection = parseElectionString()
-    if (newElection) {
-      saveElection(newElection)
+  const handleSaveElection = () => {
+    const valid = validateElectionDefinition()
+    if (valid) {
+      saveElection(electionString)
       setDirty(false)
       setError('')
     }
@@ -82,7 +82,7 @@ const DefinitionEditorScreen = () => {
 
   const downloadElectionDefinition = () => {
     fileDownload(
-      JSON.stringify(election, undefined, 2),
+      electionData,
       `${dashify(election.date)}-${dashify(election.county.name)}-${dashify(
         election.title
       )}-vx-election-definition.json`,
@@ -91,8 +91,8 @@ const DefinitionEditorScreen = () => {
   }
 
   useEffect(() => {
-    parseElectionString()
-  }, [parseElectionString, electionString])
+    validateElectionDefinition()
+  }, [validateElectionDefinition, electionString])
 
   return (
     <React.Fragment>
@@ -106,7 +106,7 @@ const DefinitionEditorScreen = () => {
           <Button
             small
             primary={dirty && !error}
-            onPress={hanldeSaveElection}
+            onPress={handleSaveElection}
             disabled={!dirty || !!error}
           >
             Save

--- a/client/src/screens/DefinitionScreen.tsx
+++ b/client/src/screens/DefinitionScreen.tsx
@@ -24,8 +24,8 @@ interface ContestSection {
 }
 
 const DefinitionScreen = () => {
-  const { election: e, configuredAt } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, configuredAt } = useContext(AppContext)
+  const { election } = electionDefinition!
 
   const electionsBySection = election.contests.reduce<ContestSection[]>(
     (prev, curr) => {

--- a/client/src/screens/ExportElectionBallotPackageScreen.tsx
+++ b/client/src/screens/ExportElectionBallotPackageScreen.tsx
@@ -17,8 +17,8 @@ import { Monospace } from '../components/Text'
 import * as workflow from '../workflows/ExportElectionBallotPackageWorkflow'
 
 const ExportElectionBallotPackageScreen = () => {
-  const { election: e, electionHash } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition } = useContext(AppContext)
+  const { election, electionData, electionHash } = electionDefinition!
   const electionLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE)
 
   const [state, setState] = useState<workflow.State>(
@@ -45,10 +45,7 @@ const ExportElectionBallotPackageScreen = () => {
                 .replace(/(^-|-$)+/g, '')
                 .toLocaleLowerCase()}-${electionHash.slice(0, 10)}.zip`,
             })
-            await state.archive.file(
-              'election.json',
-              JSON.stringify(election, undefined, 2)
-            )
+            await state.archive.file('election.json', electionData)
             await state.archive.file(
               'manifest.json',
               JSON.stringify({ ballots: state.ballotConfigs }, undefined, 2)
@@ -67,7 +64,7 @@ const ExportElectionBallotPackageScreen = () => {
         }
       }
     })()
-  }, [state, election, electionHash])
+  }, [state, election, electionData, electionHash])
 
   /**
    * Callback from `HandMarkedPaperBallot` to let us know the preview has been

--- a/client/src/screens/OvervoteCombinationReportScreen.tsx
+++ b/client/src/screens/OvervoteCombinationReportScreen.tsx
@@ -43,10 +43,12 @@ const Contest = styled.div`
 `
 
 const PairsReportScreen = () => {
-  const { castVoteRecordFiles, election: e, isOfficialResults } = useContext(
-    AppContext
-  )
-  const election = e!
+  const {
+    castVoteRecordFiles,
+    electionDefinition,
+    isOfficialResults,
+  } = useContext(AppContext)
+  const { election } = electionDefinition!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
   const castVoteRecords = castVoteRecordFiles.castVoteRecords.flat(1)
   const overvotePairTallies = getOvervotePairTallies({

--- a/client/src/screens/PrintTestDeckScreen.tsx
+++ b/client/src/screens/PrintTestDeckScreen.tsx
@@ -43,8 +43,6 @@ const TestDeckBallots = ({
   precinct,
   onAllRendered,
 }: TestDeckBallotsParams) => {
-  console.log('rendering testdeck')
-
   // generate the possibilities
   const precinctIds: string[] = precinct.id
     ? [precinct.id]
@@ -130,9 +128,8 @@ const TestDeckBallots = ({
 const TestDeckBallotsMemoized = React.memo(TestDeckBallots)
 
 const PrintTestDeckScreen = () => {
-  const { election: e, electionHash: eHash } = useContext(AppContext)
-  const election = e!
-  const electionHash = eHash!
+  const { electionDefinition } = useContext(AppContext)
+  const { election, electionHash } = electionDefinition!
   const { precinctId: p = '' } = useParams<PrecinctReportScreenProps>()
   const precinctId = p.trim()
 

--- a/client/src/screens/PrintedBallotsReportScreen.tsx
+++ b/client/src/screens/PrintedBallotsReportScreen.tsx
@@ -21,8 +21,10 @@ import find from '../utils/find'
 type PrintCounts = Dictionary<Dictionary<number>>
 
 const PrintedBallotsReportScreen = () => {
-  const { election: e, printedBallots, configuredAt } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition, printedBallots, configuredAt } = useContext(
+    AppContext
+  )
+  const { election } = electionDefinition!
 
   const totalBallotsPrinted = printedBallots.reduce(
     (count, ballot) => count + ballot.numCopies,

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -39,9 +39,11 @@ const TallyReportScreen = () => {
 
   const { precinctId } = useParams<PrecinctReportScreenProps>()
   const { scannerId } = useParams<ScannerReportScreenProps>()
-  const { castVoteRecordFiles, election: e, isOfficialResults } = useContext(
-    AppContext
-  )
+  const {
+    castVoteRecordFiles,
+    electionDefinition,
+    isOfficialResults,
+  } = useContext(AppContext)
 
   // the point of this state and effect is to show a loading screen
   // and almost immediately trigger removing the loading screen,
@@ -68,7 +70,7 @@ const TallyReportScreen = () => {
     )
   }
 
-  const election = e!
+  const { election } = electionDefinition!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
 
   const castVoteRecords = castVoteRecordFiles.castVoteRecords.flat(1)

--- a/client/src/screens/TallyScreen.tsx
+++ b/client/src/screens/TallyScreen.tsx
@@ -29,14 +29,14 @@ import Prose from '../components/Prose'
 const TallyScreen = () => {
   const {
     castVoteRecordFiles,
-    election: e,
+    electionDefinition,
     isOfficialResults,
     saveCastVoteRecordFiles,
     saveIsOfficialResults,
     setVoteCounts,
     voteCounts,
   } = useContext(AppContext)
-  const election = e!
+  const { election } = electionDefinition!
 
   const [isLoadingCVRFile, setIsLoadingCVRFile] = useState(false)
   const [isConfimingRemoveCRVs, setIsConfirmingRemoveCRVs] = useState(false)
@@ -154,9 +154,13 @@ const TallyScreen = () => {
 
     await client.setInputFile(
       electionDefinitionFile.name,
-      new File([JSON.stringify(election)], electionDefinitionFile.name, {
-        type: 'application/json',
-      })
+      new File(
+        [electionDefinition!.electionData],
+        electionDefinitionFile.name,
+        {
+          type: 'application/json',
+        }
+      )
     )
     await client.setInputFile(
       cvrFile.name,

--- a/client/src/screens/TestDeckScreen.tsx
+++ b/client/src/screens/TestDeckScreen.tsx
@@ -36,8 +36,8 @@ const allPrecincts: Precinct = {
 }
 
 const TestDeckScreen = () => {
-  const { election: e } = useContext(AppContext)
-  const election = e!
+  const { electionDefinition } = useContext(AppContext)
+  const { election } = electionDefinition!
   const { precinctId: p = '' } = useParams<PrecinctReportScreenProps>()
   const precinctId = p.trim()
 


### PR DESCRIPTION
Keep track of the exact string that was used to create the hash, and keep them in sync.

This can be deferred if we think the risk is high.