### PR TITLE
recover from SEMS conversion failure.

### DIFF
--- a/client/src/screens/UnconfiguredScreen.tsx
+++ b/client/src/screens/UnconfiguredScreen.tsx
@@ -127,9 +127,11 @@ const UnconfiguredScreen = () => {
         await getOutputFile(electionFileName)
       } catch (error) {
         console.log('failed processInputFiles()', error) // eslint-disable-line no-console
+        await client.reset()
+        setIsLoading(false)
       }
     },
-    [client, getOutputFile]
+    [client, getOutputFile, setIsLoading]
   )
 
   const updateStatus = useCallback(async () => {


### PR DESCRIPTION
We can eventually do better with an error screen and all, but at least I want this to *not crash* on bad SEMS conversion, which is what this very minimal PR does.