### PR TITLE
fix: base64-encode the QR code data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -84,6 +84,7 @@
     "@votingworks/ballot-encoder": "^4.0.0",
     "@votingworks/qrcode.react": "1.0.1",
     "array-unique": "^0.3.2",
+    "base64-js": "^1.3.1",
     "dashify": "^2.0.0",
     "dompurify": "^2.0.12",
     "fetch-mock": "^9.10.7",
@@ -110,6 +111,7 @@
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
+    "@types/base64-js": "^1.3.0",
     "@types/readable-stream": "^2.3.5",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",

--- a/client/src/components/HandMarkedPaperBallot.tsx
+++ b/client/src/components/HandMarkedPaperBallot.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import DOMPurify from 'dompurify'
 import moment from 'moment'
 import 'moment/min/locales'
+import { fromByteArray } from 'base64-js'
 import { Handler, Previewer, registerHandlers } from 'pagedjs'
 import { TFunction, StringMap } from 'i18next'
 import { useTranslation, Trans } from 'react-i18next'
@@ -201,7 +202,10 @@ class PostRenderBallotProcessor extends Handler {
           ballotId,
         })
 
-        ReactDOM.render(<QRCode level="H" value={encoded} />, qrCodeTarget)
+        ReactDOM.render(
+          <QRCode level="L" value={fromByteArray(encoded)} />,
+          qrCodeTarget
+        )
       }
     })
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1710,6 +1710,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/base64-js@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/base64-js/-/base64-js-1.3.0.tgz#c939fdba49846861caf5a246b165dbf5698a317c"
+  integrity sha512-ZmI0sZGAUNXUfMWboWwi4LcfpoVUYldyN6Oe0oJ5cCsHDU/LlRq8nQKPXhYLOx36QYSW9bNIb1vvRrD6K7Llgw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -2832,7 +2837,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==


### PR DESCRIPTION
The QR code encoders/decoders we use are sometimes wrong when the data encoded is not ASCII, so let's just give them ASCII.

Refs votingworks/vxmail#244