### PR TITLE
Add a save as PDF button to the test desk tally page

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`printing ballots, print report, and test decks 1`] = `
               role="option"
               type="button"
             >
-              back to Test Deck list
+              Back to Test Deck list
             </button>
           </p>
         </div>
@@ -199,7 +199,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
               role="option"
               type="button"
             >
-              back to Test Deck list
+              Back to Test Deck list
             </button>
           </p>
         </div>

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -195,6 +195,14 @@ exports[`printing ballots, print report, and test decks 2`] = `
           </p>
           <p>
             <button
+              class="sc-fzoLsD ivZRNV"
+              type="button"
+            >
+              Save Results Report as PDF
+            </button>
+          </p>
+          <p>
+            <button
               class="sc-fzoLsD cIOEoD"
               role="option"
               type="button"

--- a/client/src/screens/PrintTestDeckScreen.tsx
+++ b/client/src/screens/PrintTestDeckScreen.tsx
@@ -177,7 +177,7 @@ const PrintTestDeckScreen = () => {
             </p>
             <p>
               <LinkButton small to={routerPaths.printTestDecks}>
-                back to Test Deck list
+                Back to Test Deck list
               </LinkButton>
             </p>
           </Prose>

--- a/client/src/screens/TallyReportScreen.tsx
+++ b/client/src/screens/TallyReportScreen.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { useParams } from 'react-router-dom'
 import find from '../utils/find'
+import saveAsPDF from '../utils/saveAsPDF'
 
 import { fullTallyVotes, getContestTallyMeta } from '../lib/votecounting'
 
@@ -102,25 +103,6 @@ const TallyReportScreen = () => {
   const electionDate = localeWeedkayAndDate.format(new Date(election.date))
   const generatedAt = localeLongDateAndTime.format(new Date())
 
-  const saveAsPDF = async () => {
-    const precinctNameInFileName = precinctName || 'all-precincts'
-    const data = await window.kiosk!.printToPDF()
-    const fileWriter = await window.kiosk!.saveAs({
-      defaultPath: `${`tabulation-report-${election.county.name}-${election.title}`
-        .replace(/[^a-z0-9]+/gi, '-')
-        .replace(/(^-|-$)+/g, '')
-        .toLocaleLowerCase()}-${precinctNameInFileName}.pdf`,
-    })
-    if (!fileWriter) {
-      window.alert(
-        'Could not save PDF, it can only be saved to a USB device. (Or if "Cancel" was selected, ignore this message.)'
-      )
-      return
-    }
-    fileWriter.write(data)
-    await fileWriter.end()
-  }
-
   const reportMeta = (
     <p>
       {electionDate}, {election.county.name}, {election.state}
@@ -141,6 +123,19 @@ const TallyReportScreen = () => {
     return `${statusPrefix} ${election.title} Tally Report`
   }
 
+  const handleSaveAsPDF = async () => {
+    const succeeded = await saveAsPDF(
+      'tabulation-report',
+      election,
+      precinctName
+    )
+    if (!succeeded) {
+      window.alert(
+        'Could not save PDF, it can only be saved to a USB device. (Or if "Cancel" was selected, ignore this message.)'
+      )
+    }
+  }
+
   return (
     <React.Fragment>
       <NavigationScreen>
@@ -152,7 +147,7 @@ const TallyReportScreen = () => {
           </p>
           {window.kiosk && (
             <p>
-              <Button onPress={saveAsPDF}>
+              <Button onPress={handleSaveAsPDF}>
                 Save {statusPrefix} Tally Report as PDF
               </Button>
             </p>

--- a/client/src/screens/TestDeckScreen.tsx
+++ b/client/src/screens/TestDeckScreen.tsx
@@ -93,7 +93,7 @@ const TestDeckScreen = () => {
             </p>
             <p>
               <LinkButton small to={routerPaths.testDecksTally}>
-                back to Test Deck list
+                Back to Test Deck list
               </LinkButton>
             </p>
           </Prose>

--- a/client/src/screens/TestDeckScreen.tsx
+++ b/client/src/screens/TestDeckScreen.tsx
@@ -10,10 +10,13 @@ import routerPaths from '../routerPaths'
 
 import AppContext from '../contexts/AppContext'
 
+import saveAsPDF from '../utils/saveAsPDF'
+
 import PrintButton from '../components/PrintButton'
 import ButtonList from '../components/ButtonList'
 import Prose from '../components/Prose'
 import ContestTally from '../components/ContestTally'
+import Button from '../components/Button'
 
 import {
   filterTalliesByParty,
@@ -75,6 +78,19 @@ const TestDeckScreen = () => {
     new Set(election.ballotStyles.map((bs) => bs.partyId))
   )
 
+  const handleSaveAsPDF = async () => {
+    const succeeded = await saveAsPDF(
+      'test-desk-tally-report',
+      election,
+      precinct?.name
+    )
+    if (!succeeded) {
+      window.alert(
+        'Could not save PDF, it can only be saved to a USB device. (Or if "Cancel" was selected, ignore this message.)'
+      )
+    }
+  }
+
   const pageTitle = 'Test Ballot Deck Tally'
 
   if (precinct?.name) {
@@ -91,6 +107,13 @@ const TestDeckScreen = () => {
             <p>
               <PrintButton primary>Print Results Report</PrintButton>
             </p>
+            {window.kiosk && (
+              <p>
+                <Button onPress={handleSaveAsPDF}>
+                  Save Results Report as PDF
+                </Button>
+              </p>
+            )}
             <p>
               <LinkButton small to={routerPaths.testDecksTally}>
                 Back to Test Deck list

--- a/client/src/utils/saveAsPDF.test.ts
+++ b/client/src/utils/saveAsPDF.test.ts
@@ -1,0 +1,98 @@
+import { electionSample } from '@votingworks/ballot-encoder'
+import saveAsPDF from './saveAsPDF'
+import fakeKiosk from '../../test/helpers/fakeKiosk'
+import fakeFileWriter from '../../test/helpers/fakeFileWriter'
+
+test('saves pdf with expected filename for a precinct', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  const fileWriter = fakeFileWriter()
+
+  mockKiosk.saveAs.mockResolvedValueOnce(fileWriter)
+
+  const succeeded = await saveAsPDF('test', electionSample, 'name')
+  expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1)
+  expect(mockKiosk.saveAs).toHaveBeenCalledWith({
+    defaultPath: 'test-franklin-county-general-election-name.pdf',
+  })
+  expect(succeeded).toBe(true)
+})
+
+test('file path name is manipulated properly', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  const fileWriter = fakeFileWriter()
+
+  mockKiosk.saveAs.mockResolvedValue(fileWriter)
+
+  const testCases = [
+    {
+      // The file path should always be lowercased
+      prefix: 'TeSt',
+      precinctName: 'nAmE',
+      expected: 'test-franklin-county-general-election-name.pdf',
+    },
+    {
+      // The file path should always be lowercased
+      prefix: 'TEST',
+      precinctName: 'NAME',
+      expected: 'test-franklin-county-general-election-name.pdf',
+    },
+    {
+      // Dashes at the start or end of the path name should be removed
+      prefix: '-TEST',
+      precinctName: 'NAME---',
+      expected: 'test-franklin-county-general-election-name.pdf',
+    },
+    {
+      // Dashes at the start or end of the path name should be removed
+      prefix: '',
+      precinctName: '',
+      expected: 'franklin-county-general-election.pdf',
+    },
+    {
+      // Unknown characters should be replaced by dashes
+      prefix: 'te.st',
+      precinctName: 'precinct name',
+      expected: 'te-st-franklin-county-general-election-precinct-name.pdf',
+    },
+    {
+      // Multiple errors should be corrected together
+      prefix: 'Test.Report FINAL',
+      precinctName: 'precinct name---',
+      expected:
+        'test-report-final-franklin-county-general-election-precinct-name.pdf',
+    },
+  ]
+  await testCases.forEach(async function ({ prefix, precinctName, expected }) {
+    const succeeded = await saveAsPDF(prefix, electionSample, precinctName)
+    expect(mockKiosk.saveAs).toHaveBeenCalledWith({ defaultPath: expected })
+    expect(succeeded).toBe(true)
+  })
+})
+
+test('precinct name fills in all-precincts as default value', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  const fileWriter = fakeFileWriter()
+
+  mockKiosk.saveAs.mockResolvedValueOnce(fileWriter)
+
+  const succeeded = await saveAsPDF('test', electionSample)
+  expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1)
+  expect(mockKiosk.saveAs).toHaveBeenCalledWith({
+    defaultPath: 'test-franklin-county-general-election-all-precincts.pdf',
+  })
+  expect(succeeded).toBe(true)
+})
+
+test('saveAsPDF returns false when a filewriter is not returned by saveAs', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  mockKiosk.saveAs.mockResolvedValueOnce(undefined)
+
+  const succeeded = await saveAsPDF('test', electionSample)
+  expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1)
+  expect(succeeded).toBe(false)
+})

--- a/client/src/utils/saveAsPDF.ts
+++ b/client/src/utils/saveAsPDF.ts
@@ -1,0 +1,21 @@
+import { Election } from '@votingworks/ballot-encoder'
+
+export default async function saveAsPDF(
+  fileNamePrefix: string,
+  election: Election,
+  precinctName = 'all-precincts'
+): Promise<boolean> {
+  const data = await window.kiosk!.printToPDF()
+  const fileWriter = await window.kiosk!.saveAs({
+    defaultPath: `${`${fileNamePrefix}-${election.county.name}-${election.title}-${precinctName}`
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/(^-|-$)+/g, '')
+      .toLocaleLowerCase()}.pdf`,
+  })
+  if (!fileWriter) {
+    return false
+  }
+  fileWriter.write(data)
+  await fileWriter.end()
+  return true
+}


### PR DESCRIPTION
### Summary 
Adds a save as PDF button similar to the one on the unofficial results page to the test deck tally page. I also noticed the back button on this page was lowercase when it is capitalized everywhere else so I fixed that while I was here. 

### Testing 

- yarn test
- Ran locally through the ./run_kiosk_browser.sh script, navigated to the test deck tally report page. For both an individual precinct and "All precincts": Observed the new button displayed properly: 
- ![Screen Shot 2020-10-30 at 3 39 07 PM](https://user-images.githubusercontent.com/14897017/97762654-76911b00-1ac6-11eb-8c1f-fae7bfa06d1a.png)
- Clicked the new button, observed filename populated correctly and saved. Opened the saved file and compared to the version from the original print button to verify they matched. 
- Navigated to tally results page, tested the save PDF both as a single precinct and all precincts, observed the same behavior as prior to this change. 
